### PR TITLE
Room booking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# Engine Team Coding Challenge
+
+## 1. Briefing
+Please find below a coding problem we'd like you to solve. There is no “right” or “wrong” answer; rather we want to see how you code. So, make
+your code talk! You should submit your solution in a way that makes it easy for us to use. So, we expect to see a build and/or a run script. Please
+use English as the primary language in your solution to enable us to verify the behaviour. You can code in whichever language you want, but we
+would prefer Java, Scala or Python.
+
+### 1.1 What are we looking for?
+We want to see you can create production-quality code. This means naming conventions, coding style, sensible design and meaningful
+commenting. If you feel you can give your work to a brand new colleague with a minimal of hand-over, you've probably got it right. To verify your
+code, we expect to see some tests. We realize that writing even a trivial application, and having it "production ready" is a lot of work - so it's okay
+to leave "ToDo" comments in your code. Show us the intent, but don't write too much boilerplate. Show that you're coding something that is
+maintainable. You can use any library of public repositories.
+
+### 1.2 What are we not looking for?
+We don't expect you to use every design pattern you've ever heard of - only apply patterns when it makes sense to do so. We don't expect you to
+build an user interface. We're not expecting you to have optimized the solution for performance or memory size - readability is more important
+than performance. We'd like to see what you'd do under normal conditions - therefore, if you run out of time, just say so.
+
+## 2. Task description
+Imagine we have an existing system for our employees to submit booking requests for meetings for our single meeting room. However, this
+system is not checking whether the meeting room is available at the requested time.
+We want you to implement a new system for processing batches of booking requests to create a timetable for the meeting room.
+We want you to create a simple micro service which will accept HTTP requests with the text mentioned in section 2.1 Input as request body and it
+should return a text like mentioned in 2.2 Output. The endpoint should be reachable under localhost:8080/timetable-creation. You can use any
+library you want to build the service.
+
+### 2.1 Input
+Your processing service gets the following input in text form (Content-Type: text/plain) from a HTTP request.
+The first line of the input text represents the company office hours, in 24 hour clock format
+The remainder of the input represents individual booking requests. Each booking request is in the following format (no empty lines):
+* <request submission time, in the format YYYY-MM-DD HH:MM:SS> <String:employee id>
+* <meeting start time, in the format YYYY-MM-DD HH:MM> <String:meeting duration in hours>
+
+A sample text input your endpoint accepts:
+
+```0900 1730
+2018-05-17 10:17:06 EMP001
+2018-05-21 09:00 2
+2018-05-16 12:34:56 EMP002
+2018-05-21 09:00 2
+2018-05-16 09:28:23 EMP003
+2018-05-22 14:00 2
+2018-05-17 11:23:45 EMP004
+2018-05-22 16:00 1
+2018-05-15 17:29:12 EMP005
+2018-05-21 16:00 3
+2018-05-30 17:29:12 EMP006
+2018-05-21 10:00 3
+```
+
+### 2.2 Output
+Your system must provide a successful booking calendar as output, with bookings being grouped by day and sorted by starting time . For the
+sample input displayed above, your system must provide the following output and status code 200 if succeeded.
+```2018-05-21
+09:00 11:00 EMP002
+2018-05-22
+14:00 16:00 EMP003
+16:00 17:00 EMP004
+```
+
+### 2.3 Constraints
+No part of a meeting may fall outside office hours.
+Meetings may not overlap (E.g. the request of EMP002 and EMP006 overlap)
+The booking submission system only allows one submission at a time, so submission times are guaranteed to be unique.
+in case of conflicting meetings priority must be given to the one submitted earlier
+The ordering of booking submissions in the supplied input is not guaranteed. (E.g. EMP002 submitted his request before EMP001, but in
+the input they are shuffled)
+
+### 2.4 Notes
+The current requirements make no provision for alerting users of failed bookings; it is up to the user to confirm that their booking was
+successful.
+You can assume syntactically correct inputs.
+
+## 3. Submission
+Please note that your code should work on an fresh installation of a UNIX-like OS (e.g. ubuntu or macOS) with Java JDK 8, Python 2, Python 3
+and their common build tools like maven, sbt, gradle or pip preinstalled.
+Please provide us a link to a repository or an archive.
+Let us know how long you spent on it.
+**IMPORTANT** to be included in your submission:
+Add build.sh which sets up your project (e.g. setup python environment)
+Add run.sh which takes care of running your micro service on localhost:8080

--- a/boot-run.sh
+++ b/boot-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./mvnw -Dserver.port=8080 spring-boot:run
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.msl</groupId>
-	<artifactId>roombooking</artifactId>
+	<groupId>com.mls</groupId>
+	<artifactId>room-booking</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.10</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>25.1-jre</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -Dserver.port=8080 -server -jar target/room-booking-*.jar

--- a/src/main/java/com/mls/roombooking/controllers/ExceptionHandlerController.java
+++ b/src/main/java/com/mls/roombooking/controllers/ExceptionHandlerController.java
@@ -1,0 +1,48 @@
+package com.mls.roombooking.controllers;
+
+import com.mls.roombooking.exceptions.OfficeHourException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionHandlerController
+        extends ResponseEntityExceptionHandler {
+
+    private final Log logger = LogFactory.getLog(this.getClass());
+
+    @ExceptionHandler(value
+            = { Throwable.class })
+    protected ResponseEntity<Object> handleError(
+            RuntimeException ex, WebRequest request) {
+        final String msg = "Error processing the request";
+        logger.error(msg, ex);
+        return handleExceptionInternal(ex, msg,
+                new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    @ExceptionHandler(value =  java.lang.IllegalArgumentException.class)
+    protected ResponseEntity<Object> handleInput(
+            RuntimeException ex, WebRequest request) {
+        final String msg = "Error parsing the input";
+        logger.error(msg, ex);
+        return handleExceptionInternal(ex, msg,
+                new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+
+    @ExceptionHandler(value =  OfficeHourException.class)
+    protected ResponseEntity<Object> handleInvalidOfficeHours(
+            RuntimeException ex, WebRequest request) {
+        final String msg = "Error parsing the office hours: " + ex.getMessage();
+        logger.error(msg, ex);
+        return handleExceptionInternal(ex, msg,
+                new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/controllers/TimetableController.java
+++ b/src/main/java/com/mls/roombooking/controllers/TimetableController.java
@@ -1,0 +1,26 @@
+package com.mls.roombooking.controllers;
+
+import com.mls.roombooking.services.TimetableService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
+@RestController
+public class TimetableController {
+
+    @Autowired
+    private TimetableService timetableService;
+
+    @RequestMapping(method={POST}, path = "/timetable-creation", consumes = TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> create(@RequestBody String body) {
+        final String timetable = timetableService.createTimetable(body);
+        return new ResponseEntity<>(timetable, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/domains/BookingSubmission.java
+++ b/src/main/java/com/mls/roombooking/domains/BookingSubmission.java
@@ -1,0 +1,57 @@
+package com.mls.roombooking.domains;
+
+import org.joda.time.DateTime;
+
+import static com.mls.roombooking.utils.DateTimeUtils.parseDateTime;
+
+public class BookingSubmission implements Comparable<BookingSubmission> {
+
+    private static final String pattern = "yyyy-MM-dd HH:mm:ss";
+
+    public final DateTime timestamp;
+    public final String employee;
+
+    public static BookingSubmission parse(String entry) {
+        final int employeeSeparator = entry.lastIndexOf(" ");
+        final DateTime timestamp = parseDateTime(entry.substring(0, employeeSeparator), pattern);
+        final String employee = entry.substring(employeeSeparator + 1);
+        return new BookingSubmission(timestamp, employee);
+    }
+
+    private BookingSubmission(DateTime timestamp, String employee) {
+        this.timestamp = timestamp;
+        this.employee = employee;
+    }
+
+    @Override
+    public String toString() {
+        return "BookingSubmission{" +
+                "timestamp=" + timestamp +
+                ", employee='" + employee + '\'' +
+                '}';
+    }
+
+    @Override
+    public int compareTo(BookingSubmission submission) {
+        return this.timestamp.compareTo(submission.timestamp);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BookingSubmission that = (BookingSubmission) o;
+
+        if (!timestamp.equals(that.timestamp)) return false;
+        return employee.equals(that.employee);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = timestamp.hashCode();
+        result = 31 * result + employee.hashCode();
+        return result;
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/domains/BoundedTime.java
+++ b/src/main/java/com/mls/roombooking/domains/BoundedTime.java
@@ -1,0 +1,10 @@
+package com.mls.roombooking.domains;
+
+import org.joda.time.DateTime;
+
+public interface BoundedTime {
+
+    public DateTime getStart();
+    public DateTime getEnd();
+
+}

--- a/src/main/java/com/mls/roombooking/domains/MeetingRequest.java
+++ b/src/main/java/com/mls/roombooking/domains/MeetingRequest.java
@@ -1,0 +1,85 @@
+package com.mls.roombooking.domains;
+
+import com.mls.roombooking.exceptions.MeetingRequestException;
+import org.joda.time.DateTime;
+
+import static com.mls.roombooking.utils.DateTimeUtils.parseDateTime;
+
+public class MeetingRequest implements BoundedTime, Comparable<MeetingRequest> {
+
+    private static final String pattern = "yyyy-MM-dd HH:mm";
+
+    public final DateTime start;
+    public final DateTime end;
+    public final String employee;
+
+    public final DateTime getStart() {
+        return start;
+    }
+
+    public final DateTime getEnd() {
+        return end;
+    }
+
+    public static MeetingRequest parse(String entry, String employee) {
+        final int durationSeparator = entry.lastIndexOf(" ");
+        final DateTime start = parseDateTime(entry.substring(0, durationSeparator), pattern);
+        final float hours = Float.parseFloat(entry.substring(durationSeparator + 1).replace(",", "."));
+
+        final int minutes = Math.round(hours*60);
+
+        if (minutes < 0) {
+            throw new MeetingRequestException("Meeting duration must be a positive value");
+        } else if (minutes < 5) {
+            throw new MeetingRequestException("Meeting duration must be greater than 5 minutes");
+        } else if (hours > 24) {
+            throw new MeetingRequestException("Meeting duration must not exceed 24 hours");
+        }
+
+        final DateTime end = start.plusMinutes(minutes);
+
+        return new MeetingRequest(start, end, employee);
+    }
+
+    private MeetingRequest(DateTime start, DateTime end, String employee) {
+        this.start = start;
+        this.end = end;
+        this.employee = employee;
+    }
+
+    @Override
+    public int compareTo(MeetingRequest request) {
+        return this.start.compareTo(request.start);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MeetingRequest that = (MeetingRequest) o;
+
+        if (!start.equals(that.start)) return false;
+        if (!end.equals(that.end)) return false;
+        return employee.equals(that.employee);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = start.hashCode();
+        result = 31 * result + end.hashCode();
+        result = 31 * result + employee.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MeetingRequest{" +
+                "start=" + start +
+                ", end=" + end +
+                ", employee='" + employee + '\'' +
+                '}';
+    }
+
+
+}

--- a/src/main/java/com/mls/roombooking/domains/OfficeHours.java
+++ b/src/main/java/com/mls/roombooking/domains/OfficeHours.java
@@ -1,0 +1,37 @@
+package com.mls.roombooking.domains;
+
+import com.mls.roombooking.exceptions.OfficeHourException;
+import com.mls.roombooking.utils.DateTimeUtils;
+import org.joda.time.DateTime;
+
+public class OfficeHours {
+
+    public final DateTime start;
+    public final DateTime end;
+    public final boolean fullDay;
+
+    public static OfficeHours parse(String entry) throws OfficeHourException {
+        final String[] entries = entry.split(" ");
+        final DateTime start = DateTimeUtils.parseDateTime(entries[0], "HHmm");
+        final DateTime end = DateTimeUtils.parseDateTime(entries[1], "HHmm");
+        if (start.isEqual(end)) throw new OfficeHourException("Office start hour must be different than end hour");
+        if (start.isAfter(end)) throw new OfficeHourException("Office start hour must be before the end hour");
+        final boolean fullDay = start.isEqual(start.withTimeAtStartOfDay()) && end.isEqual(end.plusDays(1).withTimeAtStartOfDay().minusMinutes(1));
+        return new OfficeHours(start, end, fullDay);
+    }
+
+    private OfficeHours(DateTime start, DateTime end, boolean fullDay) {
+        this.start = start;
+        this.end = end;
+        this.fullDay = fullDay;
+    }
+
+    @Override
+    public String toString() {
+        return "OfficeHours{" +
+                "start=" + start +
+                ", end=" + end +
+                ", fullDay=" + fullDay +
+                '}';
+    }
+}

--- a/src/main/java/com/mls/roombooking/exceptions/MeetingRequestException.java
+++ b/src/main/java/com/mls/roombooking/exceptions/MeetingRequestException.java
@@ -1,0 +1,9 @@
+package com.mls.roombooking.exceptions;
+
+public class MeetingRequestException extends RuntimeException {
+
+    public MeetingRequestException(String msg) {
+        super(msg);
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/exceptions/OfficeHourException.java
+++ b/src/main/java/com/mls/roombooking/exceptions/OfficeHourException.java
@@ -1,0 +1,9 @@
+package com.mls.roombooking.exceptions;
+
+public class OfficeHourException extends RuntimeException {
+
+   public OfficeHourException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/services/TimetableBuilder.java
+++ b/src/main/java/com/mls/roombooking/services/TimetableBuilder.java
@@ -1,0 +1,31 @@
+package com.mls.roombooking.services;
+
+import com.google.common.collect.TreeMultimap;
+import com.mls.roombooking.domains.MeetingRequest;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Service;
+
+@Service
+class TimetableBuilder {
+
+    String build(TreeMultimap<DateTime, MeetingRequest> bookingMap) {
+
+        final StringBuilder bookingTimetable = new StringBuilder();
+
+        bookingMap.keySet().forEach(date -> {
+            bookingTimetable.append(date.toString("yyyy-MM-dd")).append("\n");
+
+            for (MeetingRequest meetingRequest : bookingMap.get(date)) {
+
+                final String startTime = meetingRequest.start.toString("HH:mm");
+                final String endTime = meetingRequest.end.toString("HH:mm");
+                bookingTimetable.append(startTime).append(" ").append(endTime).append(" ").
+                        append(meetingRequest.employee).append("\n");
+            }
+
+        });
+
+        return bookingTimetable.toString().trim();
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/services/TimetableParser.java
+++ b/src/main/java/com/mls/roombooking/services/TimetableParser.java
@@ -1,0 +1,77 @@
+package com.mls.roombooking.services;
+
+import com.mls.roombooking.domains.MeetingRequest;
+import com.mls.roombooking.domains.BookingSubmission;
+import com.mls.roombooking.domains.OfficeHours;
+import com.mls.roombooking.utils.DateTimeUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+@Service
+class TimetableParser {
+
+    private final Log logger = LogFactory.getLog(this.getClass());
+
+    private boolean validHours(MeetingRequest meetingRequest, OfficeHours officeHours) {
+
+        final boolean differentDays = !DateTimeUtils.isSameDay(meetingRequest.start, meetingRequest.end);
+
+        //meeting hour is always valid for 24x7 offices
+        if (officeHours.fullDay) {
+            return true;
+        //if the meeting start and end are on different days, the office had to be 24x7
+        } else if (differentDays) {
+            return false;
+        } else {
+            //checks if meeting is within office hours
+           return meetingRequest.start.getSecondOfDay() >= officeHours.start.getSecondOfDay() &&
+                    meetingRequest.end.getSecondOfDay() <= officeHours.end.getSecondOfDay();
+        }
+    }
+
+    SortedMap<BookingSubmission, MeetingRequest> parse(String timetableRequest) {
+
+        //a tree map is used to guarantee the order of the keys, since the meeting
+        //priority depends on the booking submission timestamp
+        final TreeMap<BookingSubmission, MeetingRequest> bookingMap = new TreeMap<>();
+
+        final String[] lines = timetableRequest.trim().split("\\n");
+
+        if (timetableRequest.trim().isEmpty() || lines.length == 0) {
+            return bookingMap;
+        }
+
+        //first line represents office hours
+        final OfficeHours officeHours = OfficeHours.parse(lines[0]);
+
+        //following pairs of line represent a submission followed by the meeting request
+        for (int i = 1 ; i < lines.length ; i+= 2) {
+
+            //invalid pair won't prevent further pairs from being correctly parsed
+            try {
+                final BookingSubmission bookingSubmission = BookingSubmission.parse(lines[i]);
+                final MeetingRequest meetingRequest = MeetingRequest.parse(lines[i+1], bookingSubmission.employee);
+
+                final boolean meetingBeforeSubmission = meetingRequest.start.isBefore(bookingSubmission.timestamp);
+
+                //valid <submission,meeting> pair and meeting within working hours
+                if (!meetingBeforeSubmission && validHours(meetingRequest, officeHours)) {
+                    bookingMap.put(bookingSubmission, meetingRequest);
+                }
+            } catch (Throwable t) {
+                final String message = "Error when parsing booking lines " + i + " and " + (i+1) + ":\n"
+                        + lines[i] + "\n" + lines[i+1] + "\n" + t.getMessage();
+               logger.warn(message);
+            }
+
+        }
+
+        return bookingMap;
+
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/services/TimetableService.java
+++ b/src/main/java/com/mls/roombooking/services/TimetableService.java
@@ -1,0 +1,51 @@
+package com.mls.roombooking.services;
+
+import com.google.common.collect.TreeMultimap;
+import com.mls.roombooking.domains.MeetingRequest;
+import com.mls.roombooking.domains.BookingSubmission;
+import com.mls.roombooking.utils.DateTimeUtils;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.SortedMap;
+
+@Service
+public class TimetableService {
+
+    @Autowired
+    private TimetableParser timetableParser;
+
+    @Autowired
+    private TimetableBuilder timetableBuilder;
+
+    private TreeMultimap<DateTime, MeetingRequest> timetable(
+            SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting) {
+
+        //A tree multimap is used to group multiple meetings by meeting start date
+        //and to keep the meetings also ordered by date
+        TreeMultimap<DateTime, MeetingRequest> dateToMeetings = TreeMultimap.create();
+
+        //the submissionToMeeting map is already sorted by submission timestamp, it ensures
+        //that higher priority requests are analysed first and take precedence over conflicts
+        submissionToMeeting.forEach((bookingSubmission, bookingRequest) -> {
+
+            final DateTime dateKey = bookingRequest.start.withTimeAtStartOfDay();
+            final Set<MeetingRequest> approvedRequests = dateToMeetings.get(dateKey);
+
+            if (!DateTimeUtils.isConflicting(bookingRequest, approvedRequests)) {
+                dateToMeetings.put(dateKey, bookingRequest);
+            }
+
+        });
+
+        return dateToMeetings;
+    }
+
+    public String createTimetable(String timetableRequest) {
+        SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(timetableRequest);
+        return timetableBuilder.build(timetable(submissionToMeeting));
+    }
+
+}

--- a/src/main/java/com/mls/roombooking/utils/DateTimeUtils.java
+++ b/src/main/java/com/mls/roombooking/utils/DateTimeUtils.java
@@ -1,0 +1,32 @@
+package com.mls.roombooking.utils;
+
+import com.mls.roombooking.domains.BoundedTime;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+
+import java.util.Set;
+
+public class DateTimeUtils {
+
+    public static DateTime parseDateTime(String entry, String pattern) {
+        return DateTime.parse(entry, DateTimeFormat.forPattern(pattern));
+    }
+
+    public static boolean isSameDay(DateTime date1, DateTime date2) {
+        return date1.withTimeAtStartOfDay().isEqual(date2.withTimeAtStartOfDay());
+    }
+
+    public static boolean isConflicting(BoundedTime event, Set<? extends BoundedTime> otherEvents) {
+        final long eventStartTime = event.getStart().getMillis();
+        final long eventEndTime = event.getEnd().getMillis();
+
+        //checks if the event conflicts with any of the other events
+        return otherEvents.stream().anyMatch(request -> {
+            final long startTime = request.getStart().getMillis();
+            final long endTime = request.getEnd().getMillis();
+            return (eventStartTime >= startTime && eventStartTime < endTime) || (
+                    eventEndTime > startTime && eventEndTime <= endTime);
+        });
+    }
+
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- configuration file for LogBack (slf4J implementation)
+See here for more details: http://gordondickens.com/wordpress/2013/03/27/sawing-through-the-java-loggers/ -->
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <!-- To enable JMX Management -->
+    <jmxConfigurator/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{60} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Specify logging levels -->
+    <logger name="org.springframework" level="warn"/>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/java/com/mls/roombooking/api/SmokeTest.java
+++ b/src/test/java/com/mls/roombooking/api/SmokeTest.java
@@ -1,0 +1,121 @@
+package com.mls.roombooking.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureJson
+@AutoConfigureJsonTesters
+public class SmokeTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @Test
+    public void respondWithEmptyTimetable() throws Exception {
+        this.mockMvc.perform(post("/timetable-creation").contentType(TEXT_PLAIN_VALUE)
+                .content("0900 1700\n"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    public void respondWithTimetable() throws Exception {
+
+        final String input = "0900 1730\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 12:34:56 EMP002\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 09:28:23 EMP003\n" +
+                "2018-05-22 14:00 2\n" +
+                "2018-05-17 11:23:45 EMP004\n" +
+                "2018-05-22 16:00 1\n" +
+                "2018-05-15 17:29:12 EMP005\n" +
+                "2018-05-21 16:00 3\n" +
+                "2018-05-30 17:29:12 EMP006\n" +
+                "2018-05-21 10:00 3";
+
+        final String expected = "2018-05-21\n" +
+                "09:00 11:00 EMP002\n" +
+                "2018-05-22\n" +
+                "14:00 16:00 EMP003\n" +
+                "16:00 17:00 EMP004";
+
+
+        this.mockMvc.perform(post("/timetable-creation").contentType(TEXT_PLAIN_VALUE)
+                .content(input))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expected));
+    }
+
+    @Test
+    public void respondWithPartialTimetable() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-02-17 10:17:06 EMP001\n" +
+                "2018-02-21 08:00 1\n" +
+                "2018-02-16 12:34:56 EMP002\n" +
+                "2018-03-21 09:00 2\n" +
+                "2018-04-16 12:34:56 EMP012\n" +
+                "2018-05-05 19:00 5\n" +
+                "2018-05-07 09:28:23 EMP003\n" +
+                "2018-05-08 09:00 8\n" +
+                "2018-05-09 11:23:45 EMP004\n" +
+                "2018-05-11 16:00 1\n" +
+                "2018-05-07 09:28:26 EMP015\n" +
+                "2018-05-11 09:00 2\n" +
+                "2018-05-15 17:29:12 EMP005\n" +
+                "2018-05-13 16:00 3\n" +
+                "2018-05-15 17:29:12 EMP006\n" +
+                "2018-05-30 10:00 24\n" +
+                "2018-05-17 17:29:12 EMP008\n" +
+                "2018-05-30 10:00 -3\n" +
+                "2018-05-19 17:29:12 EMP009\n" +
+                "2018-05-30 10:00 0\n" +
+                "2018-05-20 17:29:12 EMP010\n" +
+                "2018-05-30 110:00 0\n" +
+                "2018-05-23 17:29:12 EMP011\n" +
+                "2018-05-30 10:00 ,4\n" +
+                "2018-05-10 17:29:12 EMP013\n" +
+                "2018-09-20 10:00 1\n" +
+                "2018-05-10 17:28:12 EMP014\n" +
+                "2018-09-20 09:00 1.50\n" +
+                "2018-05-25 17:29:12 EMP007\n" +
+                "2018-05-30 10:00 1.5";
+
+        final String expected = "2018-03-21\n" +
+                "09:00 11:00 EMP002\n" +
+                "2018-05-08\n" +
+                "09:00 17:00 EMP003\n" +
+                "2018-05-11\n" +
+                "09:00 11:00 EMP015\n" +
+                "16:00 17:00 EMP004\n" +
+                "2018-05-30\n" +
+                "10:00 10:24 EMP011\n" +
+                "2018-09-20\n" +
+                "09:00 10:30 EMP014";
+
+
+        this.mockMvc.perform(post("/timetable-creation").contentType(TEXT_PLAIN_VALUE)
+                .content(input))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expected));
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/controllers/TimetableControllerTest.java
+++ b/src/test/java/com/mls/roombooking/controllers/TimetableControllerTest.java
@@ -1,0 +1,62 @@
+package com.mls.roombooking.controllers;
+
+import com.mls.roombooking.services.TimetableService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJsonTesters;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(TimetableController.class)
+@AutoConfigureJson
+@AutoConfigureJsonTesters
+public class TimetableControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TimetableService timetableService;
+
+    @Test
+    public void respondWithTimetabledBookings() throws Exception {
+        final String input = "0900 1730\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 12:34:56 EMP002\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 09:28:23 EMP003\n" +
+                "2018-05-22 14:00 2\n" +
+                "2018-05-17 11:23:45 EMP004\n" +
+                "2018-05-22 16:00 1\n" +
+                "2018-05-15 17:29:12 EMP005\n" +
+                "2018-05-21 16:00 3\n" +
+                "2018-05-30 17:29:12 EMP006\n" +
+                "2018-05-21 10:00 3";
+
+        final String expected = "2018-05-21\n" +
+                "09:00 11:00 EMP002\n" +
+                "2018-05-22\n" +
+                "14:00 16:00 EMP003\n" +
+                "16:00 17:00 EMP004";
+
+        when(timetableService.createTimetable(anyString())).thenReturn(expected);
+        this.mockMvc.perform(post("/timetable-creation")
+                .contentType(TEXT_PLAIN_VALUE)
+                .content(input))
+                .andExpect(status().isOk())
+                .andExpect(content().string(expected));
+    }
+}

--- a/src/test/java/com/mls/roombooking/domains/BookingSubmissionTest.java
+++ b/src/test/java/com/mls/roombooking/domains/BookingSubmissionTest.java
@@ -1,0 +1,38 @@
+package com.mls.roombooking.domains;
+
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static com.mls.roombooking.utils.DateTimeUtils.parseDateTime;
+
+@RunWith(SpringRunner.class)
+public class BookingSubmissionTest {
+
+    private final String pattern = "yyy-MM-dd HH:mm:ss";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void buildBookingSubmission() throws Exception {
+        final BookingSubmission bookingSubmission = BookingSubmission.parse("2018-05-17 10:17:06 EMP001");
+        final DateTime time = parseDateTime("2018-05-17 10:17:06", pattern);
+
+        Assert.assertEquals(time, bookingSubmission.timestamp);
+        Assert.assertEquals("EMP001", bookingSubmission.employee);
+    }
+
+    @Test
+    public void failBuildBookingSubmissionWithInvalidTimestamp() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Invalid format: \"2018-05-17 10:17\" is too short");
+        BookingSubmission.parse("2018-05-17 10:17 EMP001");
+    }
+
+
+}

--- a/src/test/java/com/mls/roombooking/domains/MeetingRequestTest.java
+++ b/src/test/java/com/mls/roombooking/domains/MeetingRequestTest.java
@@ -1,0 +1,123 @@
+package com.mls.roombooking.domains;
+import static com.mls.roombooking.utils.DateTimeUtils.parseDateTime;
+
+import com.mls.roombooking.exceptions.MeetingRequestException;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class MeetingRequestTest {
+
+    private final String pattern = "yyy-MM-dd HH:mm";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void buildMeetingRequest() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 2", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-21 17:00", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+        Assert.assertEquals("EMP", meetingRequest.employee);
+    }
+
+    @Test
+    public void buildMeetingRequestOverlappingDays() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 23", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-22 14:00", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+    }
+
+    @Test
+    public void buildMeetingRequestWithPartialHours() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 2.75", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-21 17:45", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+    }
+
+    @Test
+    public void buildMeetingRequestWithPartialHoursUsingComma() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 2,75", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-21 17:45", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+    }
+
+    @Test
+    public void build5MinutesMeeting() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 0.083333333", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-21 15:05", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+    }
+
+    @Test
+    public void build24hMeeting() throws Exception {
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 24", "EMP");
+        final DateTime startTime = parseDateTime("2018-05-21 15:00", pattern);
+        final DateTime endTime = parseDateTime("2018-05-22 15:00", pattern);
+
+        Assert.assertEquals(startTime, meetingRequest.start);
+        Assert.assertEquals(endTime, meetingRequest.end);
+    }
+
+    @Test
+    public void failToBuildMeetingWithInvalidDuration() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 -a", "EMP");
+    }
+
+    @Test
+    public void failToBuildZeroDurationMeeting() throws Exception {
+        thrown.expect(MeetingRequestException.class);
+        thrown.expectMessage("Meeting duration must be greater than 5 minutes");
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 0", "EMP");
+    }
+
+    @Test
+    public void failToBuildLessThan5MinutesMeeting() throws Exception {
+        thrown.expect(MeetingRequestException.class);
+        thrown.expectMessage("Meeting duration must be greater than 5 minutes");
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 0.07", "EMP");
+    }
+
+    @Test
+    public void failToBuildMoreThan24hMeeting() throws Exception {
+        thrown.expect(MeetingRequestException.class);
+        thrown.expectMessage("Meeting duration must not exceed 24 hours");
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 24.01", "EMP");
+    }
+
+
+    @Test
+    public void failToBuildNegativeDurationMeeting() throws Exception {
+        thrown.expect(MeetingRequestException.class);
+        thrown.expectMessage("Meeting duration must be a positive value");
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-21 15:00 -5", "EMP");
+    }
+
+    @Test
+    public void failToBuildMeetingWithInvalidDateTime() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        final MeetingRequest meetingRequest = MeetingRequest.parse("2018-05-211 15:00 5", "EMP");
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/domains/OfficeHoursTest.java
+++ b/src/test/java/com/mls/roombooking/domains/OfficeHoursTest.java
@@ -1,0 +1,66 @@
+package com.mls.roombooking.domains;
+
+import com.mls.roombooking.exceptions.OfficeHourException;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class OfficeHoursTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void buildOfficeHours() throws Exception {
+        final OfficeHours officeHours = OfficeHours.parse("0900 1730");
+        final DateTime baseTime = DateTime.now().withTimeAtStartOfDay();
+        final int expectedStart = baseTime.withHourOfDay(9).withMinuteOfHour(0).getSecondOfDay();
+        final int expectedEnd = baseTime.withHourOfDay(17).withMinuteOfHour(30).getSecondOfDay();
+        Assert.assertEquals(expectedStart, officeHours.start.getSecondOfDay());
+        Assert.assertEquals(expectedEnd, officeHours.end.getSecondOfDay());
+        Assert.assertEquals(false, officeHours.fullDay);
+    }
+
+    @Test
+    public void buildFullDayOfficeHours() throws Exception {
+        final OfficeHours officeHours = OfficeHours.parse("0000 2359");
+        final DateTime baseTime = DateTime.now().withTimeAtStartOfDay();
+        final int expectedStart = baseTime.withHourOfDay(0).withMinuteOfHour(0).getSecondOfDay();
+        final int expectedEnd = baseTime.withHourOfDay(23).withMinuteOfHour(59).getSecondOfDay();
+        Assert.assertEquals(expectedStart, officeHours.start.getSecondOfDay());
+        Assert.assertEquals(expectedEnd, officeHours.end.getSecondOfDay());
+        Assert.assertEquals(true, officeHours.fullDay);
+    }
+
+    @Test
+    public void failToBuildOfficeHoursWithNegativeHours() throws Exception {
+        thrown.expect(java.lang.IllegalArgumentException.class);
+        final OfficeHours officeHours = OfficeHours.parse("-0900 -1730");
+    }
+
+    @Test
+    public void failToBuildOfficeHoursWithWrongFormat() throws Exception {
+        thrown.expect(java.lang.IllegalArgumentException.class);
+        final OfficeHours officeHours = OfficeHours.parse("09000 00800");
+    }
+
+    @Test
+    public void failToBuildOfficeHoursWithReverseStartAndEnd() throws Exception {
+        thrown.expect(OfficeHourException.class);
+        thrown.expectMessage("Office start hour must be before the end hour");
+        final OfficeHours officeHours = OfficeHours.parse("0900 0800");
+    }
+
+    @Test
+    public void failToBuildOfficeHoursWitZeroDuration() throws Exception {
+        thrown.expect(OfficeHourException.class);
+        thrown.expectMessage("Office start hour must be different than end hour");
+        final OfficeHours officeHours = OfficeHours.parse("0900 0900");
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/services/TimetableBuilderTest.java
+++ b/src/test/java/com/mls/roombooking/services/TimetableBuilderTest.java
@@ -1,0 +1,59 @@
+package com.mls.roombooking.services;
+
+import com.google.common.collect.TreeMultimap;
+import com.mls.roombooking.domains.MeetingRequest;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+
+
+@RunWith(SpringRunner.class)
+public class TimetableBuilderTest {
+
+    private final TimetableBuilder timetableBuilder = new TimetableBuilder();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final DateTime today = DateTime.now().withDate(2018, 7, 24);
+    private final DateTime tomorrow = today.plusDays(1);
+    private final DateTime yesterday = today.minusDays(1);
+
+    @Test
+    public void buildTimetable() throws Exception {
+
+        final TreeMultimap<DateTime, MeetingRequest> requests = TreeMultimap.create();
+        requests.put(tomorrow, MeetingRequest.parse("2018-05-22 09:00 2\n", "EMP01"));
+        requests.put(today, MeetingRequest.parse("2018-05-21 11:00 2\n", "EMP03"));
+        requests.put(yesterday, MeetingRequest.parse("2018-05-21 10:00 2\n", "EMP02"));
+        requests.put(today, MeetingRequest.parse("2018-05-21 09:00 2\n", "EMP03"));
+
+        final String expected = "2018-07-23\n" +
+                "10:00 12:00 EMP02\n" +
+                "2018-07-24\n" +
+                "09:00 11:00 EMP03\n" +
+                "11:00 13:00 EMP03\n" +
+                "2018-07-25\n" +
+                "09:00 11:00 EMP01";
+
+        Assert.assertEquals(expected, timetableBuilder.build(requests));
+
+    }
+
+    @Test
+    public void buildEmptyTimetable() throws Exception {
+
+        final TreeMultimap<DateTime, MeetingRequest> requests = TreeMultimap.create();
+
+        final String expected = "";
+
+        Assert.assertEquals(expected, timetableBuilder.build(requests));
+
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/services/TimetableParserTest.java
+++ b/src/test/java/com/mls/roombooking/services/TimetableParserTest.java
@@ -1,0 +1,220 @@
+package com.mls.roombooking.services;
+
+import com.mls.roombooking.domains.MeetingRequest;
+import com.mls.roombooking.domains.BookingSubmission;
+import com.mls.roombooking.exceptions.OfficeHourException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+@RunWith(SpringRunner.class)
+public class TimetableParserTest {
+
+    private final TimetableParser timetableParser = new TimetableParser();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void buildValidBookingRequestsMap() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-02-17 10:17:06 EMP001\n" +
+                "2018-02-21 08:00 1\n" +
+                "2018-02-16 12:34:56 EMP002\n" +
+                "2018-03-21 09:00 2\n" +
+                "2018-04-16 12:34:56 EMP012\n" +
+                "2018-05-05 19:00 5\n" +
+                "2018-05-07 09:28:23 EMP003\n" +
+                "2018-05-08 09:00 8\n" +
+                "2018-05-09 11:23:45 EMP004\n" +
+                "2018-05-11 16:00 1\n" +
+                "2018-05-15 17:29:12 EMP005\n" +
+                "2018-05-13 16:00 3\n" +
+                "2018-05-15 17:29:12 EMP006\n" +
+                "2018-05-30 10:00 24\n" +
+                "2018-05-17 17:29:12 EMP008\n" +
+                "2018-05-30 10:00 -3\n" +
+                "2018-05-19 17:29:12 EMP009\n" +
+                "2018-05-30 10:00 0\n" +
+                "2018-05-20 17:29:12 EMP010\n" +
+                "2018-05-30 110:00 0\n" +
+                "2018-05-23 17:29:12 EMP011\n" +
+                "2018-05-30 10:00 ,4\n" +
+                "2018-05-25 17:29:12 EMP007\n" +
+                "2018-05-30 10:00 1.5";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+
+        Assert.assertEquals(submissionToMeeting.keySet().stream().sorted().collect(Collectors.toSet()), submissionToMeeting.keySet());
+
+        final TreeMap<BookingSubmission, MeetingRequest> expected = new TreeMap<>();
+        expected.put(BookingSubmission.parse("2018-02-16 12:34:56 EMP002"), MeetingRequest.parse("2018-03-21 09:00 2", "EMP002"));
+        expected.put(BookingSubmission.parse("2018-05-07 09:28:23 EMP003"), MeetingRequest.parse("2018-05-08 09:00 8", "EMP003"));
+        expected.put(BookingSubmission.parse("2018-05-09 11:23:45 EMP004"), MeetingRequest.parse("2018-05-11 16:00 1", "EMP004"));
+        expected.put(BookingSubmission.parse("2018-05-25 17:29:12 EMP007"), MeetingRequest.parse("2018-05-30 10:00 1.5", "EMP007"));
+        expected.put(BookingSubmission.parse("2018-05-23 17:29:12 EMP011"), MeetingRequest.parse("2018-05-30 10:00 ,4", "EMP011"));
+
+        Assert.assertEquals(expected, submissionToMeeting);
+    }
+
+    @Test
+    public void parseEmptyInput() throws Exception {
+        final String input = "  \n ";
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+    }
+
+    @Test
+    public void parseOfficeHoursOnlyInput() throws Exception {
+        final String input = "0900 1700\n";
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+    }
+
+    @Test
+    public void parseInvalidInput() throws Exception {
+        final String input = "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 2";
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Invalid format: \"2018-05-17\" is malformed at \"-05-17\"");
+        timetableParser.parse(input);
+    }
+
+    @Test
+    public void buildMeetingWithinWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 2";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+
+        final TreeMap<BookingSubmission, MeetingRequest> expected = new TreeMap<>();
+        expected.put(BookingSubmission.parse("2018-05-17 10:17:06 EMP001"), MeetingRequest.parse("2018-05-21 09:00 2", "EMP001"));
+        Assert.assertEquals(expected, submissionToMeeting);
+    }
+
+    @Test
+    public void buildMeetingWithEdgeHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 8";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+
+        final TreeMap<BookingSubmission, MeetingRequest> expected = new TreeMap<>();
+        expected.put(BookingSubmission.parse("2018-05-17 10:17:06 EMP001"), MeetingRequest.parse("2018-05-21 09:00 8", "EMP001"));
+        Assert.assertEquals(expected, submissionToMeeting);
+    }
+
+    @Test
+    public void ignoreMeetingBeforeWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 08:00 8";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void ignoreMeetingAfterWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 17:00 1";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void ignoreMeetingOutsideWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 08:00 10";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void ignoreMeetingLongerThanWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 10";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void ignoreMeetingPartiallyOutsideWorkingHours() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 16:00 1.3";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void ignoreMeetingWithTimeBeforeSubmission() throws Exception {
+
+        final String input = "0900 1700\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-17 10:015 1";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+        assert(submissionToMeeting.isEmpty());
+
+    }
+
+    @Test
+    public void buildMeetingsForAlwaysClosedOffice() throws Exception {
+
+        final String input = "0900 0900\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 0";
+
+        thrown.expect(OfficeHourException.class);
+        thrown.expectMessage("Office start hour must be different than end hour");
+
+        timetableParser.parse(input);
+    }
+
+    @Test
+    public void buildMeetingsFor24x7Office() throws Exception {
+
+        final String input = "0000 2359\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 08:00 20";
+
+        final SortedMap<BookingSubmission, MeetingRequest> submissionToMeeting = timetableParser.parse(input);
+
+        final TreeMap<BookingSubmission, MeetingRequest> expected = new TreeMap<>();
+        expected.put(BookingSubmission.parse("2018-05-17 10:17:06 EMP001"), MeetingRequest.parse("2018-05-21 08:00 20", "EMP001"));
+
+        Assert.assertEquals(expected, submissionToMeeting);
+
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/services/TimetableServiceTest.java
+++ b/src/test/java/com/mls/roombooking/services/TimetableServiceTest.java
@@ -1,0 +1,97 @@
+package com.mls.roombooking.services;
+
+import com.google.common.collect.TreeMultimap;
+import com.mls.roombooking.domains.BookingSubmission;
+import com.mls.roombooking.domains.MeetingRequest;
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.TreeMap;
+
+import static org.mockito.Mockito.when;
+
+
+@RunWith(SpringRunner.class)
+public class TimetableServiceTest {
+
+    @TestConfiguration
+    static class RoomBookingServiceTestContextConfiguration {
+
+        @Bean
+        public TimetableService roomBookingService() {
+            return new TimetableService();
+        }
+    }
+
+    @Autowired
+    private TimetableService timetableService;
+
+    @MockBean
+    private TimetableParser timetableParser;
+
+    @MockBean
+    private TimetableBuilder timetableBuilder;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * createTimetable
+     */
+
+    @Test
+    public void createTimetableWithValidNonConflictingEntries() throws Exception {
+
+        final String timetableRequest = "0900 1730\n" +
+                "2018-05-17 10:17:06 EMP001\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 12:34:57 EMP007\n" +
+                "2018-05-21 09:30 0.5\n" +
+                "2018-05-16 12:34:56 EMP002\n" +
+                "2018-05-21 09:00 2\n" +
+                "2018-05-16 09:28:23 EMP003\n" +
+                "2018-05-22 14:00 2\n" +
+                "2018-05-17 11:23:45 EMP004\n" +
+                "2018-05-22 16:00 1\n" +
+                "2018-05-15 17:29:12 EMP005\n" +
+                "2018-05-21 16:00 3\n" +
+                "2018-05-30 17:29:12 EMP006\n" +
+                "2018-05-21 10:00 3";
+
+        final String output = "2018-05-21\n" +
+                "09:00 11:00 EMP002\n" +
+                "2018-05-22\n" +
+                "14:00 16:00 EMP003\n" +
+                "16:00 17:00 EMP004";
+
+        final TreeMap<BookingSubmission, MeetingRequest> submissionToMeeting = new TreeMap<>();
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-17 10:17:06 EMP001"), MeetingRequest.parse("2018-05-21 09:00 2", "EMP001"));
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-16 12:34:56 EMP002"), MeetingRequest.parse("2018-05-21 09:00 2", "EMP002"));
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-16 09:28:23 EMP003"), MeetingRequest.parse("2018-05-22 14:00 2", "EMP003"));
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-17 11:23:45 EMP004"), MeetingRequest.parse("2018-05-22 16:00 1", "EMP004"));
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-30 17:29:12 EMP006"), MeetingRequest.parse("2018-05-21 10:00 3", "EMP006"));
+        submissionToMeeting.put(BookingSubmission.parse("2018-05-16 12:34:57 EMP007"), MeetingRequest.parse("2018-05-21 09:30 0.5", "EMP007"));
+
+        when(timetableParser.parse(timetableRequest)).thenReturn(submissionToMeeting);
+
+        final TreeMultimap<DateTime, MeetingRequest> dateToMeetings = TreeMultimap.create();
+        dateToMeetings.put(DateTime.parse("2018-05-21"), MeetingRequest.parse("2018-05-21 09:00 2", "EMP002"));
+        dateToMeetings.put(DateTime.parse("2018-05-22"), MeetingRequest.parse("2018-05-22 14:00 2", "EMP003"));
+        dateToMeetings.put(DateTime.parse("2018-05-22"), MeetingRequest.parse("2018-05-22 16:00 1", "EMP004"));
+
+        when(timetableBuilder.build(dateToMeetings)).thenReturn(output);
+
+        final String timetable = timetableService.createTimetable(timetableRequest);
+        Assert.assertEquals(output, timetable);
+    }
+
+}

--- a/src/test/java/com/mls/roombooking/utils/DateTimeUtilsTest.java
+++ b/src/test/java/com/mls/roombooking/utils/DateTimeUtilsTest.java
@@ -1,0 +1,229 @@
+package com.mls.roombooking.utils;
+
+import com.mls.roombooking.domains.BoundedTime;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.TreeSet;
+
+import static com.mls.roombooking.utils.DateTimeUtils.parseDateTime;
+
+@RunWith(SpringRunner.class)
+public class DateTimeUtilsTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * isSameDay
+     */
+
+    @Test
+    public void identifyDatesOfSameDay() throws Exception {
+        final String pattern = "yyyy-MM-dd HH:mm";
+        final DateTime date1 = DateTimeUtils.parseDateTime("2018-12-15 15:03", pattern);
+        final DateTime date2 = DateTimeUtils.parseDateTime("2018-12-15 00:59", pattern);
+        Assert.assertTrue(DateTimeUtils.isSameDay(date1, date2));
+    }
+
+    @Test
+    public void identifyDatesOfDifferentDays() throws Exception {
+        final String pattern = "yyyy-MM-dd HH:mm";
+        final DateTime date1 = DateTimeUtils.parseDateTime("2018-12-15 00:00", pattern);
+        final DateTime date2 = DateTimeUtils.parseDateTime("2018-12-14 23:59", pattern);
+        Assert.assertFalse(DateTimeUtils.isSameDay(date1, date2));
+    }
+
+    /**
+     * parseDateTime
+     * */
+
+    @Test
+    public void parseDateTimeUsingPattern() throws Exception {
+        final String pattern = "yyyy-MM-dd HH:mm";
+        final String dateTimeString = "2017-05-03 03:29";
+        final DateTime dateTime = DateTimeUtils.parseDateTime(dateTimeString, pattern);
+        assert(dateTime).equals(DateTime.parse(dateTimeString, DateTimeFormat.forPattern(pattern)));
+    }
+
+    @Test()
+    public void failParsingDateTimeForWrongPattern() throws Exception {
+        final String pattern = "yyyy-MM-dd HH:mm:ss";
+        final String dateTimeString = "2017-05-03 03:29";
+        thrown.expectMessage("Invalid format: \"2017-05-03 03:29\" is too short");
+        DateTimeUtils.parseDateTime(dateTimeString, pattern);
+    }
+
+    /**
+     * isConflicting
+     */
+
+    private class TimeBox implements BoundedTime, Comparable<TimeBox> {
+
+        private static final String pattern = "yyyy-MM-dd HH:mm";
+
+        private final DateTime start;
+        private final DateTime end;
+
+        TimeBox(String timestamp, float hours) {
+            final DateTime start = parseDateTime(timestamp, pattern);
+            final int minutes = Math.round(hours*60);
+            final DateTime end = start.plusMinutes(minutes);
+            this.start = start;
+            this.end = end;
+        }
+
+        public DateTime getStart() {
+            return start;
+        }
+
+        public DateTime getEnd() {
+            return end;
+        }
+
+        @Override
+        public int compareTo(TimeBox o) {
+            return getStart().compareTo(o.getStart());
+        }
+    }
+
+    @Test
+    public void notConflictWithEmptySet() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 09:00", 2);
+        Assert.assertFalse(DateTimeUtils.isConflicting(timeBox, new TreeSet<>()));
+    }
+
+    @Test
+    public void conflictWitEventStartingLater() throws Exception {
+        final TimeBox otherTimeBox1 = new TimeBox("2018-05-22 10:00", 2);
+        final TimeBox otherTimeBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TimeBox timeBox = new TimeBox("2018-05-22 09:00", 2);
+
+        final TreeSet<TimeBox> approvedRequests = new TreeSet<>();
+        approvedRequests.add(otherTimeBox1);
+        approvedRequests.add(otherTimeBox2);
+
+        Assert.assertTrue(DateTimeUtils.isConflicting(timeBox, approvedRequests));
+    }
+
+    @Test
+    public void conflictWithEventStartingBefore() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 11:00", 2);
+
+        final TimeBox otherBox1 = new TimeBox("2018-05-22 10:00", 2);
+        final TimeBox otherBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherBox1);
+        otherTimeBoxes.add(otherBox2);
+
+        Assert.assertTrue(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void conflictWithEventThatStartsBeforeAndEndsLater() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 11:00", 1);
+
+        final TimeBox otherBox1 = new TimeBox("2018-05-22 10:00", 2);
+        final TimeBox otherBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherBox1);
+        otherTimeBoxes.add(otherBox2);
+
+        Assert.assertTrue(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void conflictWithOverlappingDaysEvent() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-23 01:00", 1);
+
+        final TimeBox otherBox1 = new TimeBox("2018-05-22 20:00", 6);
+        final TimeBox otherBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherBox1);
+        otherTimeBoxes.add(otherBox2);
+
+        Assert.assertTrue(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void notConflictWithOverlappingDaysEvent() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-23 01:00", 1);
+
+        final TimeBox otherBox1 = new TimeBox("2018-05-22 20:00", 5 );
+        final TimeBox otherBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherBox1);
+        otherTimeBoxes.add(otherBox2);
+
+        Assert.assertFalse(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void notConflictWithLeftEdge() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 08:00",2 );
+
+        final TimeBox otherTimeBox1 = new TimeBox("2018-05-22 10:00", 2);
+        final TimeBox otherTimeBox2 = new TimeBox("2018-05-21 09:00",  2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherTimeBox1);
+        otherTimeBoxes.add(otherTimeBox2);
+
+        Assert.assertFalse(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void notConflictWithRightEdge() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 12:00", 2);
+
+        final TimeBox otherTimeBox1 = new TimeBox("2018-05-22 10:00", 2);
+        final TimeBox otherTimeBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherTimeBox1);
+        otherTimeBoxes.add(otherTimeBox2);
+
+        Assert.assertFalse(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void conflictWithinMinutes() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 12:00", 0.25f);
+
+        final TimeBox otherTimeBox1 = new TimeBox("2018-05-22 11:00", 1.5f);
+        final TimeBox otherTimeBox2 = new TimeBox("2018-05-21 09:00", 2);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherTimeBox1);
+        otherTimeBoxes.add(otherTimeBox2);
+
+        Assert.assertTrue(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+    @Test
+    public void notConflictForMinutesEdge() throws Exception {
+        final TimeBox timeBox = new TimeBox("2018-05-22 12:15", 0.25f);
+
+        final TimeBox otherTimeBox1 = new TimeBox("2018-05-22 11:00", 1.25f);
+        final TimeBox otherTimeBox2 = new TimeBox("2018-05-22 12:00", 0.25f);
+
+        final TreeSet<TimeBox> otherTimeBoxes = new TreeSet<>();
+        otherTimeBoxes.add(otherTimeBox1);
+        otherTimeBoxes.add(otherTimeBox2);
+
+        Assert.assertFalse(DateTimeUtils.isConflicting(timeBox, otherTimeBoxes));
+    }
+
+}


### PR DESCRIPTION
Implements basic functionality to cover the challenge specification.

The domain was modeled in 3 basic entities:

- OfficeHours (specifying the start and end time of the office on a single day)
- BookingSubmission (an employee submission with a unique timestamp in the booking system)
- MeetingRequest (a meeting request with start timestamp, duration in hours and employee id)

Some basic rules/validations have been added in the system, such as:
- Meetings must have at least 5 minutes
- Meetings cannot be longer than 24h
- Submission time must be before the meeting start time

Meetings can also be specified with partial hours, (half an hour, 15 minutes, etc). For that both a comma or a dot could be used, e.g. 0.5, 0,25

24x7 offices are to be specified as 0000 2359 in the office hours.

The building of the timetable has been split into 3 basic steps:
- Parsing the original input and producing a SortedMap of BookingSubmission -> MeetingRequest, in which invalid entries are already discarded (submission is ordered by timestamp, so earlier submissions take priority)
- Creating a timetable multi map of Date -> MeetingRequests, respecting the order of the submissions and rejecting conflicting time entries (the map is ordered both by key (date) and values (meeting start date time)
- Building the final timetable string based on the Date -> MeetingRequest, which consists of processing the map in the given order and formatting the output